### PR TITLE
Bump deps to work with circe 0.13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: scala
 scala:
   - 2.13.1
   - 2.12.10
-  - 2.11.12
 
 jdk:
   - openjdk11

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Quick Start
 
-To use monix-circe in an existing SBT project with Scala 2.11 or a later version, add the following dependencies to your
+To use monix-circe in an existing SBT project with Scala 2.12 or a later version, add the following dependencies to your
 `build.sbt` depending on your needs:
 
 ```scala

--- a/build.sbt
+++ b/build.sbt
@@ -24,13 +24,9 @@ lazy val contributors = Seq(
   "Avasil" -> "Piotr Gawrys"
 )
 
-def circeVersion(scalaVersion: String) = CrossVersion.partialVersion(scalaVersion) match {
-  case Some((2, 11)) => "0.11.2"
-  case _             => "0.13.0"
-}
-
 val jawnVersion = "1.0.0"
 val monixVersion = "3.2.2"
+val circeVersion = "0.13.0"
 
 val minitestVersion = "2.7.0"
 
@@ -47,7 +43,7 @@ lazy val commonSettings = Seq(
   organization := "io.monix",
 
   scalaVersion := "2.13.1",
-  crossScalaVersions := Seq("2.11.12", "2.12.10", "2.13.1"),
+  crossScalaVersions := Seq("2.12.10", "2.13.1"),
   scalacOptions ++= compilerOptions,
   scalacOptions ++= (
     if (priorTo2_13(scalaVersion.value))
@@ -67,9 +63,9 @@ lazy val commonSettings = Seq(
   testFrameworks := Seq(new TestFramework("minitest.runner.Framework")),
   libraryDependencies ++= Seq(
     "io.monix" %% "monix-reactive" % monixVersion,
-    "io.circe" %% "circe-jawn" % circeVersion(scalaVersion.value),
-    "io.circe" %% "circe-generic" % circeVersion(scalaVersion.value) % Test,
-    "io.circe" %% "circe-testing" % circeVersion(scalaVersion.value) % Test,
+    "io.circe" %% "circe-jawn" % circeVersion,
+    "io.circe" %% "circe-generic" % circeVersion % Test,
+    "io.circe" %% "circe-testing" % circeVersion % Test,
     "org.typelevel" %% "jawn-parser" % jawnVersion,
     "io.monix" %% "minitest" % minitestVersion % Test,
     "io.monix" %% "minitest-laws" % minitestVersion % Test

--- a/build.sbt
+++ b/build.sbt
@@ -26,11 +26,11 @@ lazy val contributors = Seq(
 
 def circeVersion(scalaVersion: String) = CrossVersion.partialVersion(scalaVersion) match {
   case Some((2, 11)) => "0.11.2"
-  case _             => "0.12.3"
+  case _             => "0.13.0"
 }
 
-val jawnVersion = "0.14.3"
-val monixVersion = "3.1.0"
+val jawnVersion = "1.0.0"
+val monixVersion = "3.2.2"
 
 val minitestVersion = "2.7.0"
 


### PR DESCRIPTION
Hi folks,
Not sure what your policy is for bumping dependencies, but wanted to see if I could run this update.
I am trying to use your cool library with sttp and they have lately bumped their circe and jawn deps, which made things incompatible. 
Any chance we can refresh the versions used in this project?
Cheers,
Stanis